### PR TITLE
Remove URL import from Node.js types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,5 @@
 declare module 'rebaseUrl' {
 	import { PluginCreator } from 'postcss';
-	import { URL } from 'url';
 
 	interface RebaseUrlOptions {
 		/**


### PR DESCRIPTION
`URL` is available as a global in Node and in the browser.

This package uses the global value, but import the node.js type.

The type declarations should use the same global URL type instead of requiring a Node.js type.

This fixes issues where this package is used in a browser environment: https://github.com/WordPress/gutenberg/pull/62913#discussion_r1660924273